### PR TITLE
nomnom wants full argument, opts.p is undefined

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -62,7 +62,7 @@ function main () {
     if (opts.output === '-') {
       console.log(result);
     } else {
-      fs.writeFileSync(path.resolve(path.join(opts.p || '', opts.output)), result, "utf8");
+      fs.writeFileSync(path.resolve(path.join(opts['output-dir'] || '', opts.output)), result, "utf8");
     }
   });
 }


### PR DESCRIPTION
I couldn't get the `-p` or `--output-dir` flag to work.

```
./lib/cli.js --keyword=gettext -p tests --output=messages.pot tests/wait-messages.js
```

messages.pot would always end up in the current directory. Patch uses long keyword, which nomnom likes.
