### PR TITLE
I'm not sure why, but I needed this for escodegen-0.0.20. Please check.

### DIFF
--- a/lib/jsxgettext.js
+++ b/lib/jsxgettext.js
@@ -11,7 +11,7 @@ const parser    = require('esprima');
 const escodegen = require('escodegen');
 
 const generate = escodegen.generate;
-const traverse = escodegen.traverse;
+const traverse = require('estraverse').traverse;
 
 const parse_po = require('./parse_po');
 


### PR DESCRIPTION
I don't understand internals very well, but escodegen on my fresh install does not contain traverse function.
