### PR TITLE
Use estraverse since traverse was removed from escodegen

### DIFF
--- a/lib/jsxgettext.js
+++ b/lib/jsxgettext.js
@@ -9,9 +9,10 @@ const path = require('path');
 
 const parser    = require('esprima');
 const escodegen = require('escodegen');
+const estraverse = require('estraverse');
 
 const generate = escodegen.generate;
-const traverse = escodegen.traverse;
+const traverse = estraverse.traverse;
 
 const parse_po = require('./parse_po');
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "escodegen": ">=0.0.4",
     "esprima": ">=0.9.9",
+    "estraverse": ">=1.1.1",
     "nomnom": "1.5.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The traverse function was removed in escodegen 0.0.16 and replaced
with an extra dependency on estraverse:

  https://github.com/Constellation/escodegen/commit/237e5f23a4f66027b4fe1647ddda974d7a7271ec

This is a fix for issue #12.
