### PR TITLE
msgid values needs to be escaped when folded

### DIFF
--- a/lib/jsxgettext.js
+++ b/lib/jsxgettext.js
@@ -124,7 +124,7 @@ function genComment (file, additional) {
 function msgid (str) {
   if (str.length > 72) {
     var chunks = chunkString(str);
-    return 'msgid ""\n"' + chunks.join('"\n"') + '"\n';
+    return 'msgid ""\n' + chunks.map(JSON.stringify).join('\n') + '\n';
   }
   return "msgid " + JSON.stringify(str) + "\n";
 }

--- a/tests/all.js
+++ b/tests/all.js
@@ -9,7 +9,8 @@ exports.testAll['test second_attribute'] = require('./second_attribute')['test s
 exports.testAll['test jade'] = require('./jade');
 exports.testAll['test ejs'] = require('./ejs');
 exports.testAll['test comments'] = require('./test_comment');
-exports.testAll['test expressiosn'] = require('./expressions');
+exports.testAll['test po_quotes'] = require("./po_quotes");
+exports.testAll['test expressions'] = require('./expressions');
 
 if (module == require.main) {
   require('test').run(exports);

--- a/tests/inputs/po_quotes.js
+++ b/tests/inputs/po_quotes.js
@@ -1,0 +1,2 @@
+var shrtString = gettext("Hello \"World\"\n");
+var longString = gettext("This is a long string with \"quotes\", newlines \n and such. The line should get folded");

--- a/tests/po_quotes.js
+++ b/tests/po_quotes.js
@@ -1,0 +1,27 @@
+var
+fs = require('fs'),
+jsxgettext = require('../lib/jsxgettext'),
+path = require('path');
+
+// Tests parsing files with comments
+
+exports['test quotes and newlines when folding msgid'] = function (assert, cb) {
+  // check that files with leading hash parse
+  var inputFilename = path.join(__dirname, 'inputs', 'po_quotes.js');
+  fs.readFile(inputFilename, "utf8", function (err, source) {
+    var opts = {},
+        sources = {'inputs/po_quotes.js': source},
+        result = jsxgettext.generate(sources, 'inputs/po_quotes.js', opts);
+
+    // short line is escaped properly
+    assert.ok(result.indexOf('\nmsgid "Hello \\"World\\"\\n"\n')>=0, 'short line');
+
+    // long folded line should also get escaped
+    assert.ok(result.indexOf('\n"This is a long string with \\"quotes\\", newlines \\n and such. The line should get "\n')>=0, 'long folded line');
+
+    cb();
+  });
+};
+
+
+if (module == require.main) require('test').run(exports);


### PR DESCRIPTION
Currently only short strings get escaped properly but long strings are just split and used as is without escaping. This commit forces JSON.stringify to every line of folded msgid

**Example**

Consider the following input

``` javascript
gettext('short "string"')
gettext('a long "string", ...')
```

Current PO file with invalid escaping when folding (notice the quotes around "string"):

```
msgid "short \"string\""
msgstr ""

msgid ""
"a long "string", ..."
msgstr ""
```

The same with this pull request:

```
msgid "short \"string\""
msgstr ""

msgid ""
"a long \"string\", ..."
msgstr ""
```
