### PR TITLE
Ignore IntelliJ based IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea/
 node_modules/


### PR DESCRIPTION
I use PyCharm which adds a `.idea` folder in project root. Same goes for any IntelliJ based editor such as WebStorm. Let's add that to .gitignore list.
