### PR TITLE
Add `sort` option for sorted strings in output file

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -46,6 +46,11 @@ var opts = require("nomnom")
       default: 'JavaScript',
       help: 'recognise the specified language (JavaScript, EJS, Jinja)'
    })
+   .option('sort', {
+     abbr: 's',
+     flag: true,
+     help: 'Sort the extracted strings alphabetically when generating the pot file'
+   })
    .parse();
 
 function main () {

--- a/lib/jsxgettext.js
+++ b/lib/jsxgettext.js
@@ -39,7 +39,6 @@ function checkExpr(node, keyword) {
 
 // generate extracted strings file
 function gen (sources, options) {
-  var generated = '';
   var strings = options['join-existing'] ? loadStrings(path.resolve(path.join(options['output-dir'] || '', options.output))) : {};
 
   Object.keys(sources).forEach(function (filename) {
@@ -79,25 +78,24 @@ function gen (sources, options) {
 
   });
 
-  for (var str in strings) {
-      // TODO start and "\n" are ugly, but
-      // getComment shouldn't break into multiple lines with #:
-      var start = true;
-      Object.keys(strings[str].lines).forEach(function (key) {
-        if (start) {
-          generated += "#:";
-          start = false;
-        }
-        var ln = strings[str].lines[key];
-        generated += genComment(key, ln);
-      });
-      generated += "\n" +
-                   msgid(str) +
-                   "msgstr "+JSON.stringify(strings[str].str) + "\n" +
-                   "\n";
-  }
+  var keys = Object.keys(strings);
+  if (options.sort) keys.sort();
 
-  return headerTmp + generated;
+  var generated = keys.map(function (str) {
+    // Get the comments first
+    var result = "#:" + Object.keys(strings[str].lines).map(function (key) {
+      return genComment(key, strings[str].lines[key]);
+    }).join('');
+
+    result += "\n" +
+      msgid(str) +
+      "msgstr " + JSON.stringify(strings[str].str) + "\n" +
+      "\n";
+
+    return result;
+  });
+
+  return headerTmp + generated.join('');
 }
 
 // generate extracted strings file from EJS

--- a/tests/all.js
+++ b/tests/all.js
@@ -12,6 +12,7 @@ exports.testAll['test comments'] = require('./test_comment');
 exports.testAll['test po_quotes'] = require("./po_quotes");
 exports.testAll['test expressions'] = require('./expressions');
 exports.testAll['test anonymous_functions'] = require('./anonymous_functions');
+exports.testAll['test sorting'] = require('./sorting');
 
 if (module == require.main) {
   require('test').run(exports);

--- a/tests/inputs/sorted.js
+++ b/tests/inputs/sorted.js
@@ -1,0 +1,3 @@
+gettext("Zzzz. Should be last.");
+gettext("Aloha! Should be first.");
+gettext("Greetings! Should be in the middle.");

--- a/tests/outputs/sorted.po
+++ b/tests/outputs/sorted.po
@@ -1,0 +1,31 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2012-06-24 09:50+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: inputs/sorted.js:2
+msgid "Aloha! Should be first."
+msgstr ""
+
+#: inputs/sorted.js:3
+msgid "Greetings! Should be in the middle."
+msgstr ""
+
+#: inputs/sorted.js:1
+msgid "Zzzz. Should be last."
+msgstr ""
+

--- a/tests/sorting.js
+++ b/tests/sorting.js
@@ -1,0 +1,25 @@
+var
+fs = require('fs'),
+jsxgettext = require('../lib/jsxgettext'),
+path = require('path');
+
+exports['test results should be alphabetically sorted when sort is true'] = function (assert, cb) {
+  var inputFilename = path.join(__dirname, 'inputs', 'sorted.js');
+  fs.readFile(inputFilename, "utf8", function (err, source) {
+    var opts = {sort: true},
+        sources = {'inputs/sorted.js': source},
+        result = jsxgettext.generate(sources, opts);
+    assert.equal(typeof result, 'string', 'result is a string');
+    assert.ok(result.length > 0, 'result is not empty');
+
+    var outputFilename = path.join(__dirname, 'outputs',
+                                  'sorted.po');
+
+    fs.readFile(outputFilename, function (err, source) {
+      assert.equal(result, source.toString('utf8'), 'results match');
+      cb();
+    });
+  });
+};
+
+if (module == require.main) require('test').run(exports);


### PR DESCRIPTION
Adds a `sort` option (shorthand `-s`) to allow people to get sorted
strings in the resultant file. Sorting makes the `po/pot` files
easier to follow with version control, preventing arbitrary moving of
unchanged strings in the file. It also makes debugging easier.
