### PR TITLE
Add missing jade language handling through generateFromJade() from cli.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -76,6 +76,8 @@ function gen (sources) {
     result = jsxgettext.generateFromEJS(sources, opts);
   } else if (opts.language.toUpperCase() === 'JINJA') {
     result = jsxgettext.generateFromJinja(sources, opts);
+  } else if (opts.language.toUpperCase() === 'JADE') {
+    result = jsxgettext.generateFromJade(sources, opts);
   } else {
     result = jsxgettext.generate(sources, opts);
   }


### PR DESCRIPTION
From comment on https://github.com/zaach/jsxgettext/issues/15 (btw sorry commenting on a closed issue, just thought it was such a small issue - and complementary to the issue itself - it was coherent to put it there.)
