### PR TITLE
Add basic support for parsing handlebars/moustache templates.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -44,7 +44,7 @@ var opts = require("nomnom")
       abbr: 'L',
       metavar: 'NAME',
       default: 'JavaScript',
-      help: 'recognise the specified language (JavaScript, EJS, Jinja)'
+      help: 'recognise the specified language (JavaScript, EJS, Jinja, Jade, Handlebars)'
    })
    .parse();
 
@@ -78,6 +78,8 @@ function gen (sources) {
     result = jsxgettext.generateFromJinja(sources, opts);
   } else if (opts.language.toUpperCase() === 'JADE') {
     result = jsxgettext.generateFromJade(sources, opts);
+  } else if (opts.language.toUpperCase() === 'HANDLEBARS') {
+    result = jsxgettext.generateFromHandlebars(sources, opts);
   } else {
     result = jsxgettext.generate(sources, opts);
   }

--- a/lib/jsxgettext.js
+++ b/lib/jsxgettext.js
@@ -160,11 +160,21 @@ function genEJS (ejsSources, options) {
   return gen(ejsSources, options);
 }
 
+// generate extracted strings file from Jade templates
 function genJade (jadeSources, options) {
   Object.keys(jadeSources).forEach(function (filename) {
     jadeSources[filename] = parseJade(jadeSources[filename]);
   });
   return gen(jadeSources, options);
+}
+
+
+// generate extracted strings file from Handlebars/Mustache templates
+function genHandlebars (hbSources, options) {
+  Object.keys(hbSources).forEach(function (filename) {
+    hbSources[filename] = parseHandlebars(hbSources[filename]);
+  });
+  return gen(hbSources, options);
 }
 
 // generate extracted strings file from Jinja2 templates
@@ -270,7 +280,102 @@ function parseJade(str, options) {
   return buf.join('\n');
 }
 
-exports.generate         = gen;
-exports.generateFromEJS  = genEJS;
-exports.generateFromJade = genJade;
-exports.generateFromJinja = genJinja;
+// Turn handlebars helper calls into javascript-syntax functions.
+// Also comment blocks are turned into javascript comments.
+function parseHandlebars(str, options) {
+
+  // Using regexes for parsing, ooooh yeeeahhh!
+  // Short comments:  {{! this is a comment }}
+  var shortCommentRE = /\{\{\!(.*?)\}\}/
+  // Long comments:  {{!-- this comment has {{markup}} in it --}}
+  var longCommentRE = /\{\{\!--(.*?)--\}\}/
+  // Block helpers:  {{#helper}}template content{{/helper}}
+  var blockHelperStartRE = /\{\{#(\w+)\}\}/
+  var blockHelperEndRE = /\{\{\/(\w+)\}\}/
+  // Function helpers:  {{ helper value }} or {{ helper "some string" }}
+  var singleQuotedStringWithEscapes = "'(([^']*?(\\\\')?)+)'";
+  var doubleQuotedStringWithEscapes = '"(([^"]*?(\\\\")?)+)"';
+  var funcHelperRE = new RegExp("\\{\\{\\s*(\\w+)\\s+((\\w+)|(" +
+                                singleQuotedStringWithEscapes + ")|(" +
+                                doubleQuotedStringWithEscapes + "))\\s*\\}\\}")
+
+  var buf = [];
+  var match = null;
+
+  while (str.length) {
+    // Find the earliest match of any type of tag in the string.
+    match = str.match(shortCommentRE);
+    if (match) {
+      match.type = 'comment';
+    }
+    var nextMatch = str.match(longCommentRE);
+    if (nextMatch) {
+      if (!match || nextMatch.index < match.index) {
+        match = nextMatch;
+        match.type = 'comment';
+      }
+    }
+    nextMatch = str.match(blockHelperStartRE);
+    if (nextMatch) {
+      if (!match || nextMatch.index < match.index) {
+        match = nextMatch;
+        match.type = 'block';
+      }
+    }
+    nextMatch = str.match(funcHelperRE);
+    if (nextMatch) {
+      if (!match || nextMatch.index < match.index) {
+        match = nextMatch;
+        match.type = 'func';
+      }
+    }
+    if (!match) {
+      break;
+    }
+    str = str.substring(match.index + match[0].length);
+ 
+    // Translate the match into an appropriate chunk of javascript.
+    if (match.type == 'comment') {
+      // Template comment => javascript comment
+      match[1].split("\n").forEach(function(comment) {
+        buf.push("//");
+        buf.push(comment);
+        buf.push("\n");
+      })
+    } else if (match.type == 'block') {
+      // Template block helper => javascript function call
+      var helperName = match[1];
+      buf.push(helperName)
+      buf.push('("')
+      var endMatch = str.match(blockHelperEndRE);
+      while (endMatch && endMatch[1] !== helperName) {
+        var skipTo = endMatch.index + endMatch[0].length;
+        buf.push(str.substring(0, skipTo).replace('"', '\\"'));
+        str = str.substring(skipTo);
+        endMatch = str.match(blockHelperEndRE);
+      }
+      if (endMatch) {
+        buf.push(str.substring(0, endMatch.index).replace('"', '\\"'));
+        str = str.substring(endMatch.index + endMatch[0].length);
+      } else {
+        buf.push(str.replace('"', '\\"'));
+        str = '';
+      }
+      buf.push('")\n');
+    } else if (match.type == 'func') {
+      // Template function helper => javascript function call
+      buf.push(match[1]);
+      buf.push('(');
+      buf.push(match[2]);
+      buf.push(')\n');
+    }
+  }
+
+  return buf.join('');
+}
+
+exports.generate               = gen;
+exports.generateFromEJS        = genEJS;
+exports.generateFromJade       = genJade;
+exports.generateFromHandlebars = genHandlebars;
+exports.generateFromJinja      = genJinja;

--- a/tests/all.js
+++ b/tests/all.js
@@ -9,6 +9,7 @@ exports.testAll['test leading_hash'] = require('./leading_hash')['leading hash']
 exports.testAll['test second_attribute'] = require('./second_attribute')['test second attribute'];
 exports.testAll['test jade'] = require('./jade');
 exports.testAll['test ejs'] = require('./ejs');
+exports.testAll['test handlebars'] = require('./handlebars');
 exports.testAll['test comments'] = require('./test_comment');
 exports.testAll['test po_quotes'] = require("./po_quotes");
 exports.testAll['test expressions'] = require('./expressions');

--- a/tests/handlebars.js
+++ b/tests/handlebars.js
@@ -1,0 +1,24 @@
+var fs = require('fs');
+var jsxgettext = require('../lib/jsxgettext');
+var path = require('path');
+
+exports['test handlebars'] = function (assert, cb) {
+  var inputFilename = path.join(__dirname, 'inputs', 'example.handlebars');
+  fs.readFile(inputFilename, "utf8", function (err, source) {
+
+    var opts = {},
+        sources = {'inputs/example.handlebars': source},
+        result = jsxgettext.generateFromHandlebars(sources, 'inputs/example.handlebars', opts);
+    
+    assert.equal(typeof result, 'string', 'result is a string');
+    assert.ok(result.length > 1, 'result is not empty');
+    assert.equal(result.split(/msgid ".+"/).length, 4, 'exactly three strings are found')
+    assert.notEqual(result.indexOf('msgid "translated text"'), -1, 'result contains the first string')
+    assert.notEqual(result.indexOf('msgid "block helper"'), -1, 'result contains the second string')
+    assert.notEqual(result.indexOf('msgid "so let\'s test"'), -1, 'result contains the third string')
+    cb();
+  });
+};
+
+
+if (module == require.main) require('test').run(exports);

--- a/tests/inputs/example.handlebars
+++ b/tests/inputs/example.handlebars
@@ -1,0 +1,12 @@
+Some {{ gettext "translated text"}} is matched.
+But non-translated text is not matched.
+Even with a {{ value }} embedded.
+Or if it contains the word gettext or even the _ character.
+You might also use a {{#gettext}}block helper{{/gettext}} like this.
+As long as it is {{#helper}}named properly{{/helper}} of course.
+{{! comment strings }} are passed through
+{{!-- including long-form {} comments with }} markup in them --}}
+Things that {{dont}} {{ pattern match a gettext call}} are ignored.
+And spurious { or }} or whatever markup doesn't confuse the parser.
+Escaped quotes are ok, {{gettext 'so let\'s test'}} them.
+So, do we {{gettext good}}?


### PR DESCRIPTION
This PR adds support for extracting strings from handlebars/mustache templates, like the ones we're using for emails in fxa-auth-server.  It seems to work, but I wonder if it's bloating the lib with one too many options for --language.  Maybe I should just do this transformation in a separate library.  @zaach thoughts?
