### PR TITLE
TypeError: Cannot set property 'pot-creation-date' of undefined

### DIFF
--- a/lib/jsxgettext.js
+++ b/lib/jsxgettext.js
@@ -76,7 +76,7 @@ function gen(sources, options) {
   if (options['join-existing'])
     poJSON = loadStrings(path.resolve(path.join(options['output-dir'] || '', options.output)));
 
-  if (!poJSON)
+  if (!poJSON || !poJSON.charset || !poJSON.translations || !poJSON.translations)
     poJSON = {
       charset: "utf-8",
       headers: {
@@ -89,6 +89,7 @@ function gen(sources, options) {
       },
       translations: {'': {} }
     };
+  
 
   poJSON.headers["pot-creation-date"] = new Date().toISOString().replace('T', ' ').replace(/:\d{2}.\d{3}Z/, '+0000');
 


### PR DESCRIPTION
Not quite sure why I get this failure, I suspect it might have to do with I have some older files ?

```
TypeError: Cannot set property 'pot-creation-date' of undefined
    at Object.gen [as generate] (/Users/kaareal/Code/closeterie/node_modules/jsxgettext/lib/jsxgettext.js:93:39)
    at module.exports (/Users/kaareal/Code/closeterie/lib/grunt/gettext.js:40:31)
    at async.forEach (/Users/kaareal/Code/closeterie/node_modules/grunt/node_modules/async/lib/async.js:86:13)
    at Array.forEach (native)
    at _forEach (/Users/kaareal/Code/closeterie/node_modules/grunt/node_modules/async/lib/async.js:26:24)
    at Object.async.forEach (/Users/kaareal/Code/closeterie/node_modules/grunt/node_modules/async/lib/async.js:85:9)
    at Object.module.exports (/Users/kaareal/Code/closeterie/lib/grunt/gettext.js:22:11)
    at Object.task.registerMultiTask.thisTask (/Users/kaareal/Code/closeterie/node_modules/grunt/lib/grunt/task.js:258:15)
    at Object.task.registerTask.thisTask.fn (/Users/kaareal/Code/closeterie/node_modules/grunt/lib/grunt/task.js:78:16)
    at Object.Task.start._running (/Users/kaareal/Code/closeterie/node_modules/grunt/lib/util/task.js:282:30)
```
