### PR TITLE
add recursive block parsing to the handlebars parser

### DIFF
--- a/lib/parsers/handlebars.js
+++ b/lib/parsers/handlebars.js
@@ -2,7 +2,7 @@
 
 // Turn handlebars helper calls into javascript-syntax functions.
 // Also comment blocks are turned into javascript comments.
-function parseHandlebars(str) {
+function parseHandlebars(str, recurse) {
   // Using regexes for parsing, ooooh yeeeahhh!
   // Short comments:  {{! this is a comment }}
   var shortCommentRE = /\{\{\!(.*?)\}\}/;
@@ -19,6 +19,7 @@ function parseHandlebars(str) {
                                 doubleQuotedStringWithEscapes + "))\\s*\\}\\}");
 
   var buf = [];
+  var tempBuf;
   var match = null;
 
   function addComment(comment) {
@@ -55,40 +56,58 @@ function parseHandlebars(str) {
       }
     }
     if (!match) {
+      if (recurse) buf.push(str.replace(/\n/g, '\\n'));
       break;
+    } else if (recurse) {
+      buf.push(str.substring(0, match.index).replace(/\n/g, '\\n'));
     }
     str = str.substring(match.index + match[0].length);
+
 
     // Translate the match into an appropriate chunk of javascript.
     if (match.type === 'comment') {
       // Template comment => javascript comment
       match[1].split("\n").forEach(addComment);
     } else if (match.type === 'block') {
+      if (recurse) buf.push('" + ');
       // Template block helper => javascript function call
       var helperName = match[1];
       buf.push(helperName);
       buf.push('("');
+
+      tempBuf = [];
+
       var endMatch = str.match(blockHelperEndRE);
+
       while (endMatch && endMatch[1] !== helperName) {
         var skipTo = endMatch.index + endMatch[0].length;
-        buf.push(str.substring(0, skipTo).replace('"', '\\"'));
+        tempBuf.push(str.substring(0, skipTo).replace(/"/g, '\\"'));
         str = str.substring(skipTo);
         endMatch = str.match(blockHelperEndRE);
       }
+
       if (endMatch) {
-        buf.push(str.substring(0, endMatch.index).replace('"', '\\"'));
+        tempBuf.push(str.substring(0, endMatch.index).replace(/"/g, '\\"'));
         str = str.substring(endMatch.index + endMatch[0].length);
       } else {
-        buf.push(str.replace('"', '\\"'));
+        tempBuf.push(str.replace(/"/g, '\\"'));
         str = '';
       }
+
+      var result = parseHandlebars(tempBuf.join(''), true);
+      buf.push(result);
+
       buf.push('")\n');
+      if (recurse) buf.push(' + "');
+
     } else if (match.type === 'func') {
+      if (recurse) buf.push('" + ');
       // Template function helper => javascript function call
       buf.push(match[1]);
       buf.push('(');
       buf.push(match[2]);
       buf.push(')\n');
+      if (recurse) buf.push(' + "');
     }
   }
 

--- a/test/inputs/example.handlebars
+++ b/test/inputs/example.handlebars
@@ -4,6 +4,7 @@ Even with a {{ value }} embedded.
 Or if it contains the word gettext or even the _ character.
 You might also use a {{#gettext}}block helper{{/gettext}} like this.
 As long as it is {{#helper}}named properly{{/helper}} of course.
+And {{#helper}}nesting of {{#gettext}}helpers{{/gettext}} should be ok{{/helper}} too.
 {{! comment strings }} are passed through
 {{!-- including long-form {} comments with }} markup in them --}}
 Things that {{dont}} {{ pattern match a gettext call}} are ignored.

--- a/test/tests/handlebars.js
+++ b/test/tests/handlebars.js
@@ -15,10 +15,11 @@ exports['test handlebars'] = function (assert, cb) {
     
     assert.equal(typeof result, 'string', 'result is a string');
     assert.ok(result.length > 1, 'result is not empty');
-    assert.equal(result.split(/msgid ".+"/).length, 4, 'exactly three strings are found');
-    assert.notEqual(result.indexOf('msgid "translated text"'), -1, 'result contains the first string');
-    assert.notEqual(result.indexOf('msgid "block helper"'), -1, 'result contains the second string');
-    assert.notEqual(result.indexOf('msgid "so let\'s test"'), -1, 'result contains the third string');
+    assert.equal(result.split(/msgid ".+"/).length, 5, 'exactly five strings are found')
+    assert.notEqual(result.indexOf('msgid "translated text"'), -1, 'result contains the first string')
+    assert.notEqual(result.indexOf('msgid "block helper"'), -1, 'result contains the second string')
+    assert.notEqual(result.indexOf('msgid "helpers"'), -1, 'result contains the third string')
+    assert.notEqual(result.indexOf('msgid "so let\'s test"'), -1, 'result contains the fourth string')
     cb();
   });
 };


### PR DESCRIPTION
@BYK r?

This adds recursive parsing of blocks, which a project I'm working on uses. It's ugly, but I didn't want to rewrite the entire parser right now. A proper recursive descent/ascent would be better.
