### PR TITLE
Add support for array joins

### DIFF
--- a/lib/jsxgettext.js
+++ b/lib/jsxgettext.js
@@ -11,18 +11,34 @@ var parser        = require('acorn');
 var traverse      = require('acorn/util/walk').simple;
 var gettextParser = require('gettext-parser');
 
+var isTranslatable;
+var extractStr;
+
 function isStringLiteral(node) {
   return node.type === 'Literal' && (typeof node.value === 'string');
 }
 
 function isStrConcatExpr(node) {
-  var left = node.left;
-  var right = node.right;
+  return node.type === "BinaryExpression" &&
+      node.operator === '+' &&
+      isTranslatable(node.left) &&
+      isTranslatable(node.right);
+}
 
-  return node.type === "BinaryExpression" && node.operator === '+' && (
-      (isStringLiteral(left) || isStrConcatExpr(left)) &&
-      (isStringLiteral(right) || isStrConcatExpr(right))
-  );
+function isArrayJoin(node) {
+  return node.type === 'CallExpression' &&
+    node.callee.type === 'MemberExpression' &&
+    node.callee.object.type === 'ArrayExpression' &&
+    node.callee.property.name === 'join' &&
+    isTranslatable(node.arguments[0]) &&
+    node.callee.object.elements.every(isTranslatable);
+}
+
+function isTranslatable(node) {
+  return node && (
+    isStringLiteral(node) ||
+    isStrConcatExpr(node) ||
+    isArrayJoin(node));
 }
 
 function getTranslatable(node, options) {
@@ -52,19 +68,26 @@ function getTranslatable(node, options) {
   if (funcName !== options.keyword && funcName !== 'gettext')
     return false;
 
-  if (arg && (isStrConcatExpr(arg) || isStringLiteral(arg)))
+  if (isTranslatable(arg))
     return arg;
 
   if (options.sanity)
     throw new Error("Could not parse translatable: " + JSON.stringify(arg, null, 2));
 }
 
+function extractArrayJoin(node) {
+  var joiner = extractStr(node.arguments[0]);
+  return node.callee.object.elements.map(extractStr).join(joiner);
+}
+
 // Assumes node is either a string Literal or a strConcatExpression
 function extractStr(node) {
   if (isStringLiteral(node))
     return node.value;
-  else
+  else if (isStrConcatExpr(node))
     return extractStr(node.left) + extractStr(node.right);
+  else
+    return extractArrayJoin(node);
 }
 
 function loadStrings(poFile) {

--- a/test/inputs/array_joins.js
+++ b/test/inputs/array_joins.js
@@ -1,0 +1,5 @@
+gettext([
+    "The second string is significantly longer",
+    "and we'd like to concatenate it in our source",
+    "code to avoid really wide files."
+  ].join(' '));

--- a/test/inputs/complex_array_joins.js
+++ b/test/inputs/complex_array_joins.js
@@ -1,0 +1,5 @@
+gettext([
+    "The second string is " + "significantly longer",
+    "and we'd like to concatenate it in our source",
+    ["code to avoid", "really wide files."].join(" ")
+  ].join(['', ' '].join('') + ''));

--- a/test/outputs/array_joins.pot
+++ b/test/outputs/array_joins.pot
@@ -1,0 +1,5 @@
+#: inputs/array_joins.js:1
+msgid ""
+"The second string is significantly longer and we'd like to concatenate it "
+"in our source code to avoid really wide files."
+msgstr ""

--- a/test/outputs/complex_array_joins.pot
+++ b/test/outputs/complex_array_joins.pot
@@ -1,0 +1,5 @@
+#: inputs/complex_array_joins.js:1
+msgid ""
+"The second string is significantly longer and we'd like to concatenate it "
+"in our source code to avoid really wide files."
+msgstr ""

--- a/test/tests/expressions.js
+++ b/test/tests/expressions.js
@@ -42,4 +42,30 @@ exports['test concatenated strings (issue #10)'] = function (assert, cb) {
   });
 };
 
+exports['test array joins'] = function (assert, cb) {
+  var inputFilename = path.join(__dirname, '..', 'inputs', 'array_joins.js');
+  var outputFilename = path.join(__dirname, '..', 'outputs', 'array_joins.pot');
+
+  fs.readFile(inputFilename, "utf8", function (err, source) {
+    var result = jsxgettext.generate({'inputs/array_joins.js': source}, {});
+    assert.equal(typeof result, 'string', 'result is a string');
+    assert.ok(result.length > 0, 'result is not empty');
+
+    utils.compareResultWithFile(result, outputFilename, assert, cb);
+  });
+};
+
+exports['test complex array joins'] = function (assert, cb) {
+  var inputFilename = path.join(__dirname, '..', 'inputs', 'complex_array_joins.js');
+  var outputFilename = path.join(__dirname, '..', 'outputs', 'complex_array_joins.pot');
+
+  fs.readFile(inputFilename, "utf8", function (err, source) {
+    var result = jsxgettext.generate({'inputs/complex_array_joins.js': source}, {});
+    assert.equal(typeof result, 'string', 'result is a string');
+    assert.ok(result.length > 0, 'result is not empty');
+
+    utils.compareResultWithFile(result, outputFilename, assert, cb);
+  });
+};
+
 if (module === require.main) require('test').run(exports);


### PR DESCRIPTION
It would be really cool if we could do this:

``` javascript
gettext([
  'foo',
  'bar'
].join(' '));
```
