### PR TITLE
Fix escaping of quotes in nested handlebars blocks

### DIFF
--- a/lib/parsers/handlebars.js
+++ b/lib/parsers/handlebars.js
@@ -18,6 +18,9 @@ function parseHandlebars(str, recurse) {
                                 singleQuotedStringWithEscapes + ")|(" +
                                 doubleQuotedStringWithEscapes + "))\\s*\\}\\}");
 
+  // an unescaped double quote starts with anything but an escape (\) or nothing
+  var unescapedDoubleQuote = /([^\\])"|^"/g;
+
   var buf = [];
   var tempBuf;
   var match = null;
@@ -27,6 +30,14 @@ function parseHandlebars(str, recurse) {
     buf.push(comment);
     buf.push("\n");
   }
+
+  function escapeQuotes(str) {
+    return str.replace(unescapedDoubleQuote, function (match, group) {
+      var prefix = group || '';
+      return prefix + '\\"';
+    });
+  }
+
 
   while (str.length) {
     // Find the earliest match of any type of tag in the string.
@@ -81,20 +92,20 @@ function parseHandlebars(str, recurse) {
 
       while (endMatch && endMatch[1] !== helperName) {
         var skipTo = endMatch.index + endMatch[0].length;
-        tempBuf.push(str.substring(0, skipTo).replace(/"/g, '\\"'));
+        tempBuf.push(str.substring(0, skipTo));
         str = str.substring(skipTo);
         endMatch = str.match(blockHelperEndRE);
       }
 
       if (endMatch) {
-        tempBuf.push(str.substring(0, endMatch.index).replace(/"/g, '\\"'));
+        tempBuf.push(str.substring(0, endMatch.index));
         str = str.substring(endMatch.index + endMatch[0].length);
       } else {
-        tempBuf.push(str.replace(/"/g, '\\"'));
+        tempBuf.push(str);
         str = '';
       }
 
-      var result = parseHandlebars(tempBuf.join(''), true);
+      var result = parseHandlebars(escapeQuotes(tempBuf.join('')), true);
       buf.push(result);
 
       buf.push('")\n');

--- a/test/inputs/example.handlebars
+++ b/test/inputs/example.handlebars
@@ -10,4 +10,5 @@ And {{#helper}}nesting of {{#gettext}}helpers{{/gettext}} should be ok{{/helper}
 Things that {{dont}} {{ pattern match a gettext call}} are ignored.
 And spurious { or }} or whatever markup doesn't confuse the parser.
 Escaped quotes are ok, {{gettext 'so let\'s test'}} them.
+Watch {{#helper}}out {{#foo}}{{#gettext}}for "quotes"{{/gettext}}{{/foo}}{{/helper}} too.
 So, do we {{gettext good}}?

--- a/test/tests/handlebars.js
+++ b/test/tests/handlebars.js
@@ -10,16 +10,17 @@ exports['test handlebars'] = function (assert, cb) {
   var inputFilename = path.join(__dirname, '..', 'inputs', 'example.handlebars');
   fs.readFile(inputFilename, "utf8", function (err, source) {
     var result = jsxgettext.generate.apply(jsxgettext, handlebars(
-      {'inputs/example.handlebars': source}, {})
+      {'inputs/example.handlebars': source}, { foo: true })
     );
-    
+
     assert.equal(typeof result, 'string', 'result is a string');
     assert.ok(result.length > 1, 'result is not empty');
-    assert.equal(result.split(/msgid ".+"/).length, 5, 'exactly five strings are found')
+    assert.equal(result.split(/msgid ".+"/).length, 6, 'exactly five strings are found')
     assert.notEqual(result.indexOf('msgid "translated text"'), -1, 'result contains the first string')
     assert.notEqual(result.indexOf('msgid "block helper"'), -1, 'result contains the second string')
     assert.notEqual(result.indexOf('msgid "helpers"'), -1, 'result contains the third string')
     assert.notEqual(result.indexOf('msgid "so let\'s test"'), -1, 'result contains the fourth string')
+    assert.notEqual(result.indexOf('msgid "for \\"quotes\\""'), -1, 'result contains the fourth string')
     cb();
   });
 };


### PR DESCRIPTION
Putting more lipstick on the handlebars-parsing-pig.

This fixes an issue with [nested blocks](https://github.com/mozilla/fxa-content-server/issues/1306) that results in unnecessary escapes being added on each level of nesting.
