### PR TITLE
Extract a parse function out of the generate fn

### DIFF
--- a/lib/jsxgettext.js
+++ b/lib/jsxgettext.js
@@ -75,8 +75,7 @@ function loadStrings(poFile) {
   }
 }
 
-// generate extracted strings file
-function gen(sources, options) {
+function parse(sources, options) {
   var useExisting = options['join-existing'];
   var poJSON;
   if (useExisting)
@@ -191,7 +190,13 @@ function gen(sources, options) {
     });
   });
 
-  return gettextParser.po.compile(poJSON).toString();
+  return poJSON;
+}
+exports.parse = parse;
+
+// generate extracted strings file
+function gen(sources, options) {
+  return gettextParser.po.compile(parse(sources, options)).toString();
 }
 
 exports.generate = gen;


### PR DESCRIPTION
This allows a third-party user of the library
to use the not yet compiled strings for certain things.

In my case I want to extract some parts of the generated messages.js(on) to an own file in order to have a slimmer file for the browser to download. 
