### PR TITLE
Support of JavascriptMVC EJS tags <%== and <%#

### DIFF
--- a/lib/parsers/ejs.js
+++ b/lib/parsers/ejs.js
@@ -6,16 +6,26 @@ function parseEJS(str, options) {
   var open = options.open || '<%',
     close = options.close || '%>';
 
-  var buf = [];
+  var buf = [],
+      comment;
 
   for (var i = 0, len = str.length; i < len; ++i) {
     if (str.slice(i, open.length + i) === open) {
+      comment = false;
       i += open.length;
       switch (str.substr(i, 1)) {
         case '=':
         case '-':
           ++i;
           break;
+        case '#':
+          ++i;
+          comment = true;
+      }
+
+      // Check for <%== style opening tag
+      if (str.substr(i, 1) === '=') {
+          ++i;
       }
 
       var end = str.indexOf(close, i), js = str.substring(i, end), start = i, n = 0;
@@ -28,8 +38,9 @@ function parseEJS(str, options) {
         buf.push("\n");
       }
 
-      // skip EJS include statements which are not valid javascript
-      if (/^\s*include\s*[^\s]+\s*$/.test(js)) js = "";
+      // skip EJS comments and EJS include statements which are not valid javascript
+      if (comment || /^\s*include\s*[^\s]+\s*$/.test(js)) js = "";
+
       buf.push(js, ';');
       i += end - start + close.length - 1;
 

--- a/test/inputs/comment.ejs
+++ b/test/inputs/comment.ejs
@@ -1,0 +1,1 @@
+<%# gettext("this is a non localizable comment string") %>

--- a/test/inputs/raw.ejs
+++ b/test/inputs/raw.ejs
@@ -1,0 +1,1 @@
+<%== gettext("this is a raw localizable string") %>

--- a/test/tests/ejs_comment.js
+++ b/test/tests/ejs_comment.js
@@ -1,0 +1,25 @@
+"use strict";
+
+var fs = require('fs');
+var path = require('path');
+
+var jsxgettext = require('../../lib/jsxgettext');
+var ejs = require('../../lib/parsers/ejs').ejs;
+
+exports['test ejs'] = function (assert, cb) {
+  // check that include syntax doesn't break extraction
+  var inputFilename = path.join(__dirname, '..', 'inputs', 'comment.ejs');
+  fs.readFile(inputFilename, "utf8", function (err, source) {
+    var result = jsxgettext.generate.apply(jsxgettext, ejs(
+      {'inputs/include.ejs': source}, {})
+    );
+
+    assert.equal(typeof result, 'string', 'comment result is a string');
+    assert.ok(result.length > 1, 'comment result is not empty');
+    assert.ok(result.indexOf('this is a non localizable comment string') === -1,
+              'comment strings are not extracted');
+    cb();
+  });
+};
+
+if (module === require.main) require('test').run(exports);

--- a/test/tests/ejs_raw.js
+++ b/test/tests/ejs_raw.js
@@ -1,0 +1,25 @@
+"use strict";
+
+var fs = require('fs');
+var path = require('path');
+
+var jsxgettext = require('../../lib/jsxgettext');
+var ejs = require('../../lib/parsers/ejs').ejs;
+
+exports['test ejs'] = function (assert, cb) {
+  // check that include syntax doesn't break extraction
+  var inputFilename = path.join(__dirname, '..', 'inputs', 'raw.ejs');
+  fs.readFile(inputFilename, "utf8", function (err, source) {
+    var result = jsxgettext.generate.apply(jsxgettext, ejs(
+      {'inputs/include.ejs': source}, {})
+    );
+
+    assert.equal(typeof result, 'string', 'raw result is a string');
+    assert.ok(result.length > 1, 'raw result is not empty');
+    assert.ok(result.indexOf('this is a raw localizable string') !== -1,
+              'raw localizable strings are extracted');
+    cb();
+  });
+};
+
+if (module === require.main) require('test').run(exports);


### PR DESCRIPTION
EJS parser in JavascriptMVC supports some special tags.
This PR adds supports for some of these.
- for raw (unescaped) output you can use tag <%== output %>
  (for extracting strings it treats the same as <%= output %>)
- adding comments with tag <%# Comment %>
  (for extracting strings it treats the same as the include statement:
  removes from temporary js content)

See: http://javascriptmvc.com/docs/can.EJS.html#section_MagicTags
