### PR TITLE
Make the CLI more "Unixy"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,29 +32,23 @@ Or from source:
 
     $ jsxgettext
 
-    input argument is required
 
-    Usage: jsxgettext <input>... [options]
-
-    input     input files
-
+    Usage: jsxgettext [options] [file ...]
+  
     Options:
-       -o FILE, --output FILE     write output to specified file
-       -p DIR, --output-dir DIR   output files will be placed in directory DIR
-       -v, --version              print version and exit
-       -k WORD, --keyword WORD    additional keyword to be looked for
-       -j, --join-existing        join messages with existing file
-       -L NAME, --language NAME   use the specified language (javascript, ejs, jinja, handlebars, jade)
-       -s, --sanity               sanity check during the extraction
-       --support-module           Support module to require for specific language parsers
-
-       --project-id-version "PACKAGE VERSION"   
-       (po header) This is the project name and version of the generated package/catalog.
-
-       --report-bugs-to EMAIL                   
-       (po header) An email address or URL where you can report bugs in the untranslated strings.
-
-       -c TAG, --add-comments TAG               place comment blocks starting with TAG and preceding keyword lines in output file (default: "L10n:").
+  
+      -h, --help                      output usage information
+      -V, --version                   output the version number
+      -o, --output <file>             write output to specified <file>
+      -p, --output-dir <path>         output files will be placed in directory <path>
+      -k, --keyword [keywords]        additional keywords to be looked for
+      -j, --join-existing             join messages with existing file
+      -L, --language [lang]           use the specified language (javascript, ejs, jinja, handlebars, jade, swig) [javascript]
+      -s, --sanity                    sanity check during the extraction
+      --support-module <path>         Specific parsers (e.g. swig) need a custom module to be imported. Specify it with this argument.
+      --project-id-version [version]  This is the project name and version of the generated package/catalog.
+      --report-bugs-to [bug address]  An email address or URL where you can report bugs in the untranslated strings.
+      -c, --add-comments [tag]        place comment blocks starting with TAG and preceding keyword lines in output file (default: "L10n:").
 
 ### support-module
 In order to be able to parse the templates, some language parsers need a custom

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,73 +6,21 @@ var path       = require('path');
 var parsers    = require('./parsers');
 var jsxgettext = require('./jsxgettext');
 
-var opts = require("nomnom")
-  .script('jsxgettext')
-  .option('output', {
-    abbr: 'o',
-    metavar: 'FILE',
-    default: 'messages.po',
-    help: 'write output to specified file'
-  })
-  .option('output-dir', {
-    abbr: 'p',
-    metavar: 'DIR',
-    help: 'output files will be placed in directory DIR'
-  })
-  .option('version', {
-    abbr: 'v',
-    flag: true,
-    help: 'print version and exit',
-    callback: function () {
-      return require('../package.json').version;
-    }
-  })
-  .option('input', {
-    position: 0,
-    required: true,
-    list: true,
-    help: 'input files'
-  })
-  .option('keyword', {
-    abbr: 'k',
-    metavar: 'WORD',
-    list: true,
-    help: 'additional keyword to be looked for'
-  })
-  .option('join-existing', {
-    abbr: 'j',
-    flag: true,
-    help: 'join messages with existing file'
-  })
-  .option('language', {
-    abbr: 'L',
-    metavar: 'NAME',
-    default: 'javascript',
-    help: 'use the specified language (' + ['javascript'].concat(Object.keys(parsers)).join(', ') + ')'
-  })
-  .option('sanity', {
-    abbr: 's',
-    flag: true,
-    help: "sanity check during the extraction"
-  })
-  .option('support-module', {
-    metavar: 'SUPPORTMODULE',
-    help: 'Specific parsers (e.g. swig) need a custom module to be imported. Specify it with this argument.'
-  })
-  .option('project-id-version', {
-    metavar: '"PACKAGE VERSION"',
-    help: 'This is the project name and version of the generated package/catalog.'
-  })
-  .option('report-bugs-to', {
-    metavar: 'EMAIL',
-    help: 'An email address or URL where you can report bugs in the untranslated strings.'
-  })
-  .option('add-comments', {
-    abbr: 'c',
-    metavar: 'TAG',
-    help: 'place comment blocks starting with TAG and preceding keyword lines in output file (default: "L10n:").'
-  })
-  .parse();
+var optAsList = function (val) { return val.split(','); };
+var opts = require("commander")
+  .version(require('../package.json').version)
+  .usage('[options] [file ...]')
+  .option('-o, --output <file>', 'write output to specified <file>', '-')  // default to stdout
+  .option('-p, --output-dir <path>', 'output files will be placed in directory <path>')
+  .option('-k, --keyword [keywords]', 'additional keywords to be looked for', optAsList)
+  .option('-j, --join-existing', 'join messages with existing file')
+  .option('-L, --language [lang]', 'use the specified language (' + ['javascript'].concat(Object.keys(parsers)).join(', ') + ') [javascript]', 'javascript')
+  .option('-s, --sanity', "sanity check during the extraction")
+  .option('--support-module <path>', 'Specific parsers (e.g. swig) need a custom module to be imported. Specify it with this argument.')
+  .option('--project-id-version [version]', 'This is the project name and version of the generated package/catalog.')
+  .option('--report-bugs-to [bug address]', 'An email address or URL where you can report bugs in the untranslated strings.')
+  .option('-c, --add-comments [tag]', 'place comment blocks starting with TAG and preceding keyword lines in output file (default: "L10n:").')
+  .parse(process.argv);
 
 function gen(sources) {
   var result;
@@ -93,24 +41,30 @@ function gen(sources) {
     throw new Error("Unsupported language: " + opts.language);
   }
 
-  if (opts.output === '-') {
+  if (opts.output === '-') {  // use stdout
     console.log(result);
   } else {
-    fs.writeFileSync(path.resolve(path.join(opts['output-dir'] || '', opts.output)), result, "utf8");
+    fs.writeFileSync(
+      path.resolve(path.join(opts['output-dir'] || '', opts.output)),
+      result,
+      "utf8"
+    );
   }
 }
 
 function main() {
-  var files = opts.input;
+  var files = opts.args;
   var sources = {};
 
-  if (files[0] === '-') {
+  if (!files.length || files[0] === '-') {  // read from stdin, and do it by default
     var data = '';
     process.stdin.resume();
     process.stdin.setEncoding('utf8');
+
     process.stdin.on('data', function (chunk) {
       data += chunk;
     });
+
     process.stdin.on('end', function () {
       gen({'stdin': data});
     });

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "Ryan Kelly <ryan@rfk.id.au> (http://www.rfk.id.au)"
   ],
   "name": "jsxgettext",
-  "version": "0.4.11",
+  "version": "0.5.0",
   "license": "MPL-2.0",
   "description": "Extracts gettext strings from JavaScript, EJS, Jade, Jinja and Handlebars files.",
   "keywords": [
@@ -34,7 +34,7 @@
   "dependencies": {
     "acorn": "0.7.0",
     "gettext-parser": "0.2.0",
-    "nomnom": "1.5.2",
+    "commander": "2.3.0",
     "jade": "0.30.0",
     "swig": "1.3.2",
     "escape-string-regexp": "1.0.1"


### PR DESCRIPTION
Switches the option parser to [visionmedia/commander.js](https://npmjs.org/package/commander) from nomnom to fix #67, #68.
