### PR TITLE
Fix usage of parsed options

### DIFF
--- a/lib/jsxgettext.js
+++ b/lib/jsxgettext.js
@@ -77,16 +77,16 @@ function loadStrings(poFile) {
 }
 
 function parse(sources, options) {
-  var useExisting = options['joinExisting'];
+  var useExisting = options.joinExisting;
   var poJSON;
   if (useExisting)
-    poJSON = loadStrings(path.resolve(path.join(options['outputDir'] || '', options.output)));
+    poJSON = loadStrings(path.resolve(path.join(options.outputDir || '', options.output)));
 
   if (!poJSON) {
     var headers = {
-      "project-id-version": options['projectIdVersion'] || "PACKAGE VERSION",
+      "project-id-version": options.projectIdVersion || "PACKAGE VERSION",
       "language-team": "LANGUAGE <LL@li.org>",
-      "report-msgid-bugs-to": options['reportBugsTo'],
+      "report-msgid-bugs-to": options.reportBugsTo,
       "po-revision-date": "YEAR-MO-DA HO:MI+ZONE",
       "language": "",
       "mime-version": "1.0",
@@ -117,7 +117,7 @@ function parse(sources, options) {
   }
 
   options.keyword = options.keyword || ['gettext'];
-  var tagName = options['addComments'] || "L10n:";
+  var tagName = options.addComments || "L10n:";
   var commentRegex = new RegExp([
     "^\\s*" + regExpEscape(tagName), // The "TAG" provided externally or "L10n:" by default
     "^\\/" // The "///" style comments which is the xgettext standard

--- a/test/tests/arbitrary_comments.js
+++ b/test/tests/arbitrary_comments.js
@@ -9,7 +9,7 @@ var utils = require('../utils');
 exports['test --add-comments option'] = function (assert, cb) {
   var inputFilename = path.join(__dirname, '..', 'inputs', 'arbitrary_comments.js');
   fs.readFile(inputFilename, 'utf8', function (err, source) {
-    var options = {"add-comments": "comment:"};
+    var options = {"addComments": "comment:"};
     var result = jsxgettext.generate({'inputs/arbitrary_comments.js': source}, options);
 
     assert.equal(typeof result, 'string', 'Result should be a string');

--- a/test/tests/po_custom_headers.js
+++ b/test/tests/po_custom_headers.js
@@ -5,9 +5,9 @@ var gettextParser = require('gettext-parser');
 
 exports['test po custom headers'] = function (assert, cb) {
   var opts = {
-      "project-id-version": "MyProject 1.0",
-      "report-bugs-to": "bugs@project.org",
-      "language-team": "this cannot be overridden"
+      "projectIdVersion": "MyProject 1.0",
+      "reportBugsTo": "bugs@project.org",
+      "languageTeam": "this cannot be overridden"
     },
     sources = {'dummy': ''},
     result = jsxgettext.generate(sources, opts),


### PR DESCRIPTION
[Commander does camelCase of multi-word options](https://github.com/visionmedia/commander.js#option-parsing). 

Fixes buggy change introduced in ab34d3a0818788a66308b865b856ffd67ed6434c.
