### PR TITLE
Support EJS filters

### DIFF
--- a/lib/parsers/ejs.js
+++ b/lib/parsers/ejs.js
@@ -7,7 +7,8 @@ function parseEJS(str, options) {
     close = options.close || '%>';
 
   var buf = [],
-      comment;
+      comment,
+      filtered;
 
   for (var i = 0, len = str.length; i < len; ++i) {
     if (str.slice(i, open.length + i) === open) {
@@ -26,11 +27,18 @@ function parseEJS(str, options) {
       // Check for <%== style opening tag
       if (str.substr(i, 1) === '=') {
           ++i;
+      } else if (str.substr(i, 1) === ':') {
+          ++i;
+          filtered = true;
       }
 
       var end = str.indexOf(close, i), js = str.substring(i, end), start = i, n = 0;
       if ('-' === js[js.length - 1]) {
         js = js.substring(0, js.length - 2);
+      }
+      // visionmedia/ejs treats everything after the first | as filter definitions
+      if (filtered) {
+        js = js.split('|', 1)[0];
       }
 
       while ((n = js.indexOf("\n", n)) > -1) {

--- a/test/inputs/filter.ejs
+++ b/test/inputs/filter.ejs
@@ -1,0 +1,1 @@
+<%=: gettext("this is a localizable string") | capitalize %>

--- a/test/tests/ejs_filter.js
+++ b/test/tests/ejs_filter.js
@@ -1,0 +1,25 @@
+"use strict";
+
+var fs = require('fs');
+var path = require('path');
+
+var jsxgettext = require('../../lib/jsxgettext');
+var ejs = require('../../lib/parsers/ejs').ejs;
+
+exports['test ejs'] = function (assert, cb) {
+  // check that include syntax doesn't break extraction
+  var inputFilename = path.join(__dirname, '..', 'inputs', 'filter.ejs');
+  fs.readFile(inputFilename, "utf8", function (err, source) {
+    var result = jsxgettext.generate.apply(jsxgettext, ejs(
+      {'inputs/filter.ejs': source}, {})
+    );
+
+    assert.equal(typeof result, 'string', 'result is a string');
+    assert.ok(result.length > 1, 'result is not empty');
+    assert.ok(result.indexOf('this is a localizable string') !== -1,
+              'localizable strings are extracted');
+    cb();
+  });
+};
+
+if (module === require.main) require('test').run(exports);


### PR DESCRIPTION
`<%=: name | uppercase %>` and the like. Only content before the `|` is considered for extraction. The parser is pretty loose, but matches what [visionmedia/ejs](https://github.com/visionmedia/ejs/blob/master/ejs.js#L106) does.

See: https://github.com/visionmedia/ejs#filters
