### PR TITLE
Swig: Fix gettext function call with newline

### DIFF
--- a/lib/parsers/swig.js
+++ b/lib/parsers/swig.js
@@ -19,7 +19,7 @@ function parseSwig(str, filename, options) {
 
   var buf = [];
   var transTagRegex = /\{%\s*trans\s+['"]{1}(.+?)['"]{1}\s*%\}/mig;
-  var gettextRegex = new RegExp(keyword + '\\([\'"]{1}(.+?)[\'"]{1}\\)', 'mig');
+  var gettextRegex = new RegExp(keyword + '\\([\'"]{1}(.+?)[\'"]{1}[^)]*\\)', 'mig');
   var blockTransRegex = /\{%\s*blocktrans.+?%}(((?!(\{%\s*endblocktrans\s*%\}))(?:\n|.))+)\{%\s*endblocktrans\s*%\}/mig;
   var matches, i, l, lineMatch, match, blockStr;
 

--- a/test/inputs/example.swig
+++ b/test/inputs/example.swig
@@ -7,6 +7,9 @@ foobar
 {{url}}
 
 {% set foobar = gettext("Test gettext directly") %}
+{% set foobar = gettext("Test with additional params on new line", {
+	'foo': 'bar'
+}) %}
 
 {% blocktrans with name=name url=url %}
 Hello <a href="%(url)s">%(name)s</a>.

--- a/test/tests/swig.js
+++ b/test/tests/swig.js
@@ -18,6 +18,7 @@ exports['test single file parsing'] = function (assert, cb) {
     assert.ok(result.length > 1, 'result is not empty');
     assert.ok(result.indexOf('msgid "Hello foobar"') > -1, 'Trans tag found');
     assert.ok(result.indexOf('msgid "Test gettext directly"') > -1, 'Gettext function call found');
+    assert.ok(result.indexOf('msgid "Test with additional params on new line"') > -1, 'Gettext with newline function call found');
     assert.ok(result.indexOf('msgid "Hello <a href=\\"%(url)s\\">%(name)s</a>. Pleasure to meet you."') > -1, 'Blocktrans tag found');
     cb();
   });


### PR DESCRIPTION
We changed the `gettext` function sent to the templates by combining `format` and `gettext` into one function. In case this possibility is used & newlines are being used, the previous regex failed.
