### PR TITLE
Remove requirement to have comments in pre-existing po template

### DIFF
--- a/lib/jsxgettext.js
+++ b/lib/jsxgettext.js
@@ -171,7 +171,9 @@ function parse(sources, options) {
             }
           };
         } else {
-          translations[str].comments.reference +=  '\n' + ref;
+          if(translations[str].comments) {
+            translations[str].comments.reference +=  '\n' + ref;
+          }
           if (comments)
             translations[str].comments.extracted += '\n' + comments;
         }


### PR DESCRIPTION
Was throwing errors when using a `pot` without comments.

I often use `--no-location` to helps keep code diffs sane.
