### PR TITLE
fix parsing gettext from jade attributes

### DIFF
--- a/lib/parsers/jade.js
+++ b/lib/parsers/jade.js
@@ -31,7 +31,7 @@ function parseJade(str, options) {
 
   function extractFromObj(key) {
     /* jshint -W040 */
-    return extractGettext(this[key]);
+    return extractGettext(this[key].val);
   }
 
   function isEmpty(obj) {

--- a/test/inputs/second_attribute.jade
+++ b/test/inputs/second_attribute.jade
@@ -1,6 +1,10 @@
 
 p(title=gettext('foo'))= gettext('bar')
-| #{ gettext('same-lime') } #{ gettext('in text') }
+| #{ gettext('same-line') } #{ gettext('in text') }
 span= gettext('foobar')
 p= _('underscored')
-img(alt=_('underscored'),title=_('underscored'))
+img(alt=_('underscored 1'),title=_('underscored 2'))
+a(
+	data-tip=_("data attribute")
+	title=_("attribute - one per line")
+)= gettext("value  - one per line")

--- a/test/tests/jade.js
+++ b/test/tests/jade.js
@@ -6,7 +6,13 @@ var path = require('path');
 var jsxgettext = require('../../lib/jsxgettext');
 var jade = require('../../lib/parsers/jade').jade;
 
+
 exports['test parsing'] = function (assert, cb) {
+  function assertMsg(result, msg) {
+    msg = '"' + msg + '"';
+    assert.ok(result.indexOf('msgid ' + msg) > -1, msg + ' is found');
+  }
+
   // check that files with leading hash parse
   var inputFilename = path.join(__dirname, '..', 'inputs', 'second_attribute.jade');
   fs.readFile(inputFilename, "utf8", function (err, source) {
@@ -17,11 +23,17 @@ exports['test parsing'] = function (assert, cb) {
 
     assert.equal(typeof result, 'string', 'result is a string');
     assert.ok(result.length > 1, 'result is not empty');
-    assert.ok(result.indexOf('msgid "bar"') > -1, 'bar is found');
-    assert.ok(result.indexOf('msgid "same-lime"') > -1, 'same-lime is found');
-    assert.ok(result.indexOf('msgid "in text"') > -1, 'in text is found');
-    assert.ok(result.indexOf('msgid "foobar"') > -1, 'foobar is found');
-    assert.ok(result.indexOf('msgid "underscored"') > -1, 'underscored is found');
+    assertMsg(result, 'bar');
+    assertMsg(result, 'same-line');
+    assertMsg(result, 'in text');
+    assertMsg(result, 'foobar');
+    assertMsg(result, 'underscored');
+    assertMsg(result, 'underscored 1');
+    assertMsg(result, 'underscored 2');
+
+    assertMsg(result, 'data attribute');
+    assertMsg(result, 'attribute - one per line');
+    assertMsg(result, 'value  - one per line');
     cb();
   });
 };


### PR DESCRIPTION
look up the attribute value before applying regular expression
make tests more robust: use unique strings and ' and " combination

Chances are I broke this in #87 - the phrase 'underscore' was used in couple of places, which meant we never actually tested attributes parsing.