### PR TITLE
Jade parser improvements

### DIFF
--- a/lib/parsers/jade.js
+++ b/lib/parsers/jade.js
@@ -34,24 +34,37 @@ function parseJade(str, options) {
     return extractGettext(this[key].val);
   }
 
-  function isEmpty(obj) {
-    return obj.length;
+  var buf = [], lineN, lineAdjust = -1;
+
+  function append(text) {
+    /* jshint -W040 */
+    var ctx = this;
+    if (ctx && ctx.bump) {
+      lineN += 1;
+    }
+    if (text.length) {
+      buf[lineN] = [buf[lineN], text, ';'].join('');
+    }
   }
 
-  var buf = [], lineN, tmp;
   do {
     token = lexer.next();
-    lineN = token.line - 1;
+    lineN = token.line + lineAdjust;
     switch (token.type) {
       case 'attrs':
-        tmp = Object.keys(token.attrs).map(extractFromObj, token.attrs).filter(isEmpty);
-        if (tmp.length)
-          buf[lineN] = tmp.join(';') + ';';
+        Object.keys(token.attrs)
+          .map(extractFromObj, token.attrs)
+          .forEach(append);
         break;
       case 'text':
       case 'code':
-        tmp = extractGettext(token.val);
-        if (tmp.length) buf[lineN] = tmp + ';';
+        append(extractGettext(token.val));
+        break;
+      case 'pipeless-text':
+        token.val
+          .map(extractGettext)
+          .forEach(append, { bump: true });
+        lineAdjust += token.val.length;
         break;
     }
   } while (token.type !== 'eos');

--- a/lib/parsers/jade.js
+++ b/lib/parsers/jade.js
@@ -66,6 +66,11 @@ function parseJade(str, options) {
           .forEach(append, { bump: true });
         lineAdjust += token.val.length;
         break;
+      case 'comment':
+        if (/^\s*L10n:/.test(token.val)) {
+          append(['/*', token.val, '*/'].join(''));
+        }
+        break;
     }
   } while (token.type !== 'eos');
 

--- a/test/inputs/example.jade
+++ b/test/inputs/example.jade
@@ -1,0 +1,23 @@
+- var value = "v"
+p
+  | Some #{ gettext("translated text") } is matched.
+  | Event if it #{ _("uses underscore") }.
+  | Or #{ _('has several translations') } #{ gettext("in one line") }
+  | But non-translated text is not matched.
+  | Even with a #{value} embedded.
+  | Or if it contains the word gettext or even the _ character.
+
+p= _("because sometimes one need context")
+  span= gettext('and yeah - feel free to use " here')
+  // look out for those quotes
+  span= _("or to use ' here")
+
+//- of course other types of comments are ignored
+// even if the look like gettext('invocation')
+
+p Have fun with #{ _('attributes') }
+  a(
+    data-custom=gettext("because jade generally doesn't care")
+    date-extrea=_('how you format your line')
+    href='/this/is/not/something/you/want/to/translate'
+  )= _('This link better points somewhere!')

--- a/test/inputs/example.jade
+++ b/test/inputs/example.jade
@@ -12,14 +12,14 @@ p.
   is absolutely supported
   and BTW #{ gettext("this is line 13") }
 
+//- L10n: comments for translator would be cool
 p= _("because sometimes one need context")
   span= gettext('and yeah - feel free to use " here')
   // look out for those quotes
   span= _("or to use ' here")
 
-//- of course other types of comments are ignored
-// even if the look like gettext('invocation')
-
+//- other types of comments are ignored
+//- even if the look like L10n: or gettext('invocation')
 p Have fun with #{ _('attributes') }
   a(
     data-custom=gettext("because jade generally doesn't care")

--- a/test/inputs/example.jade
+++ b/test/inputs/example.jade
@@ -7,6 +7,11 @@ p
   | Even with a #{value} embedded.
   | Or if it contains the word gettext or even the _ character.
 
+p.
+  Modern #{ _('pipeless multiline syntax') }
+  is absolutely supported
+  and BTW #{ gettext("this is line 13") }
+
 p= _("because sometimes one need context")
   span= gettext('and yeah - feel free to use " here')
   // look out for those quotes
@@ -20,4 +25,6 @@ p Have fun with #{ _('attributes') }
     data-custom=gettext("because jade generally doesn't care")
     date-extrea=_('how you format your line')
     href='/this/is/not/something/you/want/to/translate'
-  )= _('This link better points somewhere!')
+  )= _('This link is in line 28 and it better points somewhere!')
+
+  span(data-custom=gettext("or you can"), data-extra=_('put multiple attributes'))= _('in line one line (30)')

--- a/test/outputs/jade.pot
+++ b/test/outputs/jade.pot
@@ -14,30 +14,50 @@ msgstr ""
 msgid "in one line"
 msgstr ""
 
-#: inputs/example.jade:10
-msgid "because sometimes one need context"
-msgstr ""
-
 #: inputs/example.jade:11
-msgid "and yeah - feel free to use \" here"
+msgid "pipeless multiline syntax"
 msgstr ""
 
 #: inputs/example.jade:13
-msgid "or to use ' here"
+msgid "this is line 13"
+msgstr ""
+
+#: inputs/example.jade:15
+msgid "because sometimes one need context"
+msgstr ""
+
+#: inputs/example.jade:16
+msgid "and yeah - feel free to use \" here"
 msgstr ""
 
 #: inputs/example.jade:18
-msgid "attributes"
-msgstr ""
-
-#: inputs/example.jade:19
-msgid "because jade generally doesn't care"
-msgstr ""
-
-#: inputs/example.jade:19
-msgid "how you format your line"
+msgid "or to use ' here"
 msgstr ""
 
 #: inputs/example.jade:23
-msgid "This link better points somewhere!"
+msgid "attributes"
+msgstr ""
+
+#: inputs/example.jade:24
+msgid "because jade generally doesn't care"
+msgstr ""
+
+#: inputs/example.jade:24
+msgid "how you format your line"
+msgstr ""
+
+#: inputs/example.jade:28
+msgid "This link is in line 28 and it better points somewhere!"
+msgstr ""
+
+#: inputs/example.jade:30
+msgid "or you can"
+msgstr ""
+
+#: inputs/example.jade:30
+msgid "put multiple attributes"
+msgstr ""
+
+#: inputs/example.jade:30
+msgid "in line one line (30)"
 msgstr ""

--- a/test/outputs/jade.pot
+++ b/test/outputs/jade.pot
@@ -22,15 +22,16 @@ msgstr ""
 msgid "this is line 13"
 msgstr ""
 
-#: inputs/example.jade:15
+#: inputs/example.jade:16
+#. L10n: comments for translator would be cool
 msgid "because sometimes one need context"
 msgstr ""
 
-#: inputs/example.jade:16
+#: inputs/example.jade:17
 msgid "and yeah - feel free to use \" here"
 msgstr ""
 
-#: inputs/example.jade:18
+#: inputs/example.jade:19
 msgid "or to use ' here"
 msgstr ""
 

--- a/test/outputs/jade.pot
+++ b/test/outputs/jade.pot
@@ -1,0 +1,43 @@
+#: inputs/example.jade:3
+msgid "translated text"
+msgstr ""
+
+#: inputs/example.jade:4
+msgid "uses underscore"
+msgstr ""
+
+#: inputs/example.jade:5
+msgid "has several translations"
+msgstr ""
+
+#: inputs/example.jade:5
+msgid "in one line"
+msgstr ""
+
+#: inputs/example.jade:10
+msgid "because sometimes one need context"
+msgstr ""
+
+#: inputs/example.jade:11
+msgid "and yeah - feel free to use \" here"
+msgstr ""
+
+#: inputs/example.jade:13
+msgid "or to use ' here"
+msgstr ""
+
+#: inputs/example.jade:18
+msgid "attributes"
+msgstr ""
+
+#: inputs/example.jade:19
+msgid "because jade generally doesn't care"
+msgstr ""
+
+#: inputs/example.jade:19
+msgid "how you format your line"
+msgstr ""
+
+#: inputs/example.jade:23
+msgid "This link better points somewhere!"
+msgstr ""

--- a/test/tests/jade.js
+++ b/test/tests/jade.js
@@ -6,35 +6,21 @@ var path = require('path');
 var jsxgettext = require('../../lib/jsxgettext');
 var jade = require('../../lib/parsers/jade').jade;
 
+var utils = require('../utils');
 
 exports['test parsing'] = function (assert, cb) {
-  function assertMsg(result, msg) {
-    msg = '"' + msg + '"';
-    assert.ok(result.indexOf('msgid ' + msg) > -1, msg + ' is found');
-  }
-
-  // check that files with leading hash parse
-  var inputFilename = path.join(__dirname, '..', 'inputs', 'second_attribute.jade');
+  var inputFilename = path.join(__dirname, '..', 'inputs', 'example.jade');
   fs.readFile(inputFilename, "utf8", function (err, source) {
-
     var opts = {keyword: ['gettext', '_']},
-        sources = {'inputs/second_attribute.jade': source},
+        sources = {'inputs/example.jade': source},
         result = jsxgettext.generate.apply(jsxgettext, jade(sources, opts));
 
     assert.equal(typeof result, 'string', 'result is a string');
-    assert.ok(result.length > 1, 'result is not empty');
-    assertMsg(result, 'bar');
-    assertMsg(result, 'same-line');
-    assertMsg(result, 'in text');
-    assertMsg(result, 'foobar');
-    assertMsg(result, 'underscored');
-    assertMsg(result, 'underscored 1');
-    assertMsg(result, 'underscored 2');
+    assert.ok(result.length > 0, 'result is not empty');
 
-    assertMsg(result, 'data attribute');
-    assertMsg(result, 'attribute - one per line');
-    assertMsg(result, 'value  - one per line');
-    cb();
+    var outputFilename = path.join(__dirname, '..', 'outputs', 'jade.pot');
+
+    utils.compareResultWithFile(result, outputFilename, assert, cb);
   });
 };
 


### PR DESCRIPTION
- use standard jsxgettext test infrastructure
- add support for *pipeless* multiline text.
- add support for L10n comments

Comments, suggestions?