### PR TITLE
I started working on context function pgettext

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ ngettext("Here's an apple for you", "Here are %s apples for you", 3);
 ngettext("Here's an apple" + ' for you', "Here are %s apples" + ' for you', 3);
 myModule.ngettext("Here's an apple" + ' for you', "Here are %s apples" + ' for you', 3);
 ngettext.call(myObj, "Here's an apple" + ' for you', "Here are %s apples" + ' for you', 3);
+pgettext("context", "This is world");
+pgettext("context", "This " + "is" +" world");
+myModule.pgettext("context", "This " + "is" +" world");
+pgettext.call(myObj, "context", "This is world");
 ```
 
 It also extracts comments that begin with "L10n:" when they appear above or next to a `gettext` call:

--- a/lib/jsxgettext.js
+++ b/lib/jsxgettext.js
@@ -58,6 +58,10 @@ function getTranslatable(node, options) {
   if (arg && funcName.substr(0, 1) === "n" && (isStrConcatExpr(arg) || isStringLiteral(arg)) && node.arguments[1] && (isStrConcatExpr(node.arguments[1]) || isStringLiteral(node.arguments[1])))
     return [arg, node.arguments[1]];
 
+    // If the gettext function's name starts with "p" (i.e. pgettext or p_) and its first 2 arguments are strings, we regard it as a context function
+  if (arg && funcName.substr(0, 1) === "p" && (isStrConcatExpr(arg) || isStringLiteral(arg)) && node.arguments[1] && (isStrConcatExpr(node.arguments[1]) || isStringLiteral(node.arguments[1])))
+    return [node.arguments[1], arg, "CTX"];
+
   if (arg && (isStrConcatExpr(arg) || isStringLiteral(arg)))
     return arg;
 
@@ -124,10 +128,11 @@ function parse(sources, options) {
   if( options.keyword ) {
     Object.keys(options.keyword).forEach(function (index) {
       options.keyword.push('n' + options.keyword[index]);
+      options.keyword.push('p' + options.keyword[index]);
     });
   }
   else {
-    options.keyword = ['gettext', 'ngettext'];
+    options.keyword = ['gettext', 'ngettext', 'pgettext'];
   }
   var tagName = options.addComments || "L10n:";
   var commentRegex = new RegExp([
@@ -186,8 +191,14 @@ function parse(sources, options) {
             }
           };
           if( arg.constructor === Array ) {
-              translations[str].msgid_plural = extractStr(arg[1]);
-              translations[str].msgstr = ['', ''];
+              //If this is context string
+              if (arg.length === 3) {
+                  translations[str].msgctxt = extractStr(arg[1]);
+              //this is plural
+              } else {
+                translations[str].msgid_plural = extractStr(arg[1]);
+                translations[str].msgstr = ['', ''];
+              }
           }
         } else {
           if(translations[str].comments) {

--- a/test/inputs/anonymous_functions.js
+++ b/test/inputs/anonymous_functions.js
@@ -3,9 +3,11 @@
 var testObj = {
     somemethod: function () {},
     gettext: function () {},
-    ngettext: function () {}
+    ngettext: function () {},
+    pgettext: function () {}
 };
 
 testObj.somemethod('I shall not pass');
 testObj.gettext("I'm gonna get translated, yay!");
 testObj.ngettext("I'm also gonna get translated!", "I'm the plural form!", 2);
+testObj.pgettext("context", "This needs to be translated");

--- a/test/inputs/concat.js
+++ b/test/inputs/concat.js
@@ -13,3 +13,10 @@ ngettext(
     "code to avoid really wide files.",
     3
 );
+
+pgettext(
+    "context",
+    "Key can actually be "+
+    "very long. Even over " +
+    "multiple lines."
+);

--- a/test/inputs/expressions.js
+++ b/test/inputs/expressions.js
@@ -6,7 +6,10 @@ var templates = {
     subject3: test.something.someotherthing['gettext'].call(test, "Confirm email address for Persona 3", somethingelse),
     subject4: test.ngettext("Confirm email address for Persona 4", "Confirm email address for Persona 4 plural", 4),
     subject5: test.ngettext.call(test, "Confirm email address for Persona 5", "Confirm email address for Persona 5 plural", 5),
-    subject6: test.something.someotherthing['ngettext'].call(test, "Confirm email address for Persona 6", "Confirm email address for Persona 6 plural", 6, somethingelse)
+    subject6: test.something.someotherthing['ngettext'].call(test, "Confirm email address for Persona 6", "Confirm email address for Persona 6 plural", 6, somethingelse),
+    subject7: test.pgettext("context", "Confirm for person 7 context"),
+    subject8: test.pgettext.call(test, "context", "Confirm for person 8 context"),
+    subject9: test.something.someotherthing['pgettext'].call(test, "context", "Confirm for person 9 context", somethingelse)
   }
 };
 

--- a/test/inputs/filter.ejs
+++ b/test/inputs/filter.ejs
@@ -1,2 +1,3 @@
 <%=: gettext("this is a localizable string") | capitalize %>
 <%=: ngettext("this is a localizable singular string", "this is a localizable plural string", 2) | capitalize %>
+<%=: pgettext("context", "this is a localizable string with context") | capitalize %>

--- a/test/inputs/first.js
+++ b/test/inputs/first.js
@@ -1,3 +1,4 @@
 var msg = gettext('Hello World');
 var dup = gettext('This message is used twice.');
 var dup2 = ngettext('This other message is used twice.', 'This other message is used twice. - plural', 2);
+var dup3 = pgettext('context_dup', 'This message is used twice in context.');

--- a/test/inputs/include.ejs
+++ b/test/inputs/include.ejs
@@ -1,3 +1,4 @@
 <% include this/include/syntax/is/kinda/dumb %>
 <%= gettext("this is a localizable string") %>
 <%= ngettext("this is a localizable singular string", "this is a localizable plural string", 2) %>
+<%= pgettext("context", "this is a localizable string with context") %>

--- a/test/inputs/multiple_keywords.js
+++ b/test/inputs/multiple_keywords.js
@@ -5,3 +5,7 @@ gettext('should NOT be translatable since we did not define it as keyword');
 n_('should be translatable - singular', 'should be translatable - plural', 2);
 nt('should also be translatable - singular', 'should also be translatable - plural', 2);
 ngettext('should NOT be translatable since we did not define it as keyword - singular', 'should NOT be translatable since we did not define it as keyword - plural', 2);
+
+p_('context', 'should be translatable context');
+pt('context', 'should also be translatable context');
+pgettext('context', 'should NOT be translatable since we did not define it as keyword');

--- a/test/inputs/raw.ejs
+++ b/test/inputs/raw.ejs
@@ -1,3 +1,4 @@
 <%== gettext("this is a raw localizable string") %>
 <%== gettext("this is a raw localizable string") %>
 <%== ngettext("this is a raw localizable singular string", "this is a raw localizable plural string", 2) %>
+<%== pgettext("context", "this is a raw localizable string with context") %>

--- a/test/inputs/second.js
+++ b/test/inputs/second.js
@@ -1,2 +1,3 @@
 var dup = gettext('This message is used twice.');
 var dup2 = ngettext('This other message is used twice.', 'This other message is used twice. - plural', 2);
+var dup3 = pgettext('context_dup', 'This message is used twice in context.');

--- a/test/outputs/anonymous_functions.pot
+++ b/test/outputs/anonymous_functions.pot
@@ -1,9 +1,14 @@
-#: inputs/anonymous_functions.js:10
+#: inputs/anonymous_functions.js:11
 msgid "I'm gonna get translated, yay!"
 msgstr ""
 
-#: inputs/anonymous_functions.js:11
+#: inputs/anonymous_functions.js:12
 msgid "I'm also gonna get translated!"
 msgid_plural "I'm the plural form!"
 msgstr[0] ""
 msgstr[1] ""
+
+#: inputs/anonymous_functions.js:13
+msgctxt "context"
+msgid "This needs to be translated"
+msgstr ""

--- a/test/outputs/concat.pot
+++ b/test/outputs/concat.pot
@@ -13,3 +13,8 @@ msgid_plural ""
 "concatenate it in our source code to avoid really wide files."
 msgstr[0] ""
 msgstr[1] ""
+
+#: inputs/concat.js:17
+msgctxt "context"
+msgid "Key can actually be very long. Even over multiple lines."
+msgstr ""

--- a/test/outputs/expressions.pot
+++ b/test/outputs/expressions.pot
@@ -27,3 +27,18 @@ msgid "Confirm email address for Persona 6"
 msgid_plural "Confirm email address for Persona 6 plural"
 msgstr[0] ""
 msgstr[1] ""
+
+#: inputs/expressions.js:10
+msgctxt "context"
+msgid "Confirm for person 7 context"
+msgstr ""
+
+#: inputs/expressions.js:11
+msgctxt "context"
+msgid "Confirm for person 8 context"
+msgstr ""
+
+#: inputs/expressions.js:12
+msgctxt "context"
+msgid "Confirm for person 9 context"
+msgstr ""

--- a/test/outputs/messages_firstpass.pot
+++ b/test/outputs/messages_firstpass.pot
@@ -11,3 +11,8 @@ msgid "This other message is used twice."
 msgid_plural "This other message is used twice. - plural"
 msgstr[0] ""
 msgstr[1] ""
+
+#: inputs/first.js:4
+msgctxt "context_dup"
+msgid "This message is used twice in context."
+msgstr ""

--- a/test/outputs/messages_secondpass.pot
+++ b/test/outputs/messages_secondpass.pot
@@ -13,3 +13,9 @@ msgid "This other message is used twice."
 msgid_plural "This other message is used twice. - plural"
 msgstr[0] ""
 msgstr[1] ""
+
+#: inputs/first.js:4
+#: inputs/second.js:3
+msgctxt "context_dup"
+msgid "This message is used twice in context."
+msgstr ""

--- a/test/outputs/multiple_keywords.pot
+++ b/test/outputs/multiple_keywords.pot
@@ -17,3 +17,13 @@ msgid "should also be translatable - singular"
 msgid_plural "should also be translatable - plural"
 msgstr[0] ""
 msgstr[1] ""
+
+#: inputs/multiple_keywords.js:9
+msgctxt "context"
+msgid "should be translatable context"
+msgstr ""
+
+#: inputs/multiple_keywords.js:10
+msgctxt "context"
+msgid "should also be translatable context"
+msgstr ""

--- a/test/tests/ejs.js
+++ b/test/tests/ejs.js
@@ -20,6 +20,8 @@ exports['test ejs'] = function (assert, cb) {
               'localizable strings are extracted');
     assert.ok(result.indexOf('this is a localizable plural string') !== -1,
               'localizable plural strings are extracted');
+    assert.ok(result.indexOf('this is a localizable string with context') !== -1,
+              'localizable strings with context are extracted');
     cb();
   });
 };

--- a/test/tests/ejs_filter.js
+++ b/test/tests/ejs_filter.js
@@ -20,6 +20,8 @@ exports['test ejs'] = function (assert, cb) {
               'localizable strings are extracted');
     assert.ok(result.indexOf('this is a localizable plural string') !== -1,
               'localizable plural strings are extracted');
+    assert.ok(result.indexOf('this is a localizable string with context') !== -1,
+              'localizable strings with context are extracted');
     cb();
   });
 };

--- a/test/tests/ejs_raw.js
+++ b/test/tests/ejs_raw.js
@@ -20,6 +20,8 @@ exports['test ejs'] = function (assert, cb) {
               'raw localizable strings are extracted');
     assert.ok(result.indexOf('this is a raw localizable plural string') !== -1,
               'raw localizable plural strings are extracted');
+    assert.ok(result.indexOf('this is a raw localizable string with context') !== -1,
+              'localizable strings with context are extracted');
     cb();
   });
 };


### PR DESCRIPTION
I needed context support so I added it. Since library supports everything else.

My addition is a little hackish IMHO I added third item in list which is returned from getTranslatable. So normal gettext returns item, plural returns 2 item array, context 3 item. First item is key second is context.

Any suggestions for improvement are welcome. I'm not at home in Javascript I think I changed all the necessary code. I'll add some handlebar tests.

Working on #94.
Extracting works. I also added tests. I updated same tests that adding ngettext changed.

Joining works if I parse both files (they are correctly deduplicated). But If I join with existing messages.pot like join test is doing they are joined incorrectly.

In addition to correctly joined msgid there is another from the second file