### PR TITLE
Parse plural forms in jade source

### DIFF
--- a/lib/parsers/jade.js
+++ b/lib/parsers/jade.js
@@ -17,8 +17,9 @@ function parseJade(str, options) {
 
   options.keyword = options.keyword || ['gettext'];
 
-  var gettextRegexPrefix = '(?:' + options.keyword.map(escapeRegExp).join('|') + ')';
-  var gettexRegex = new RegExp(gettextRegexPrefix + '(?:\\(\"[^"]+\"|\\(\'[^\']+\')', 'gi');
+  var gettextRegexPrefix = '\\w*(?:' + options.keyword.map(escapeRegExp).join('|') + ')';
+  var argRegex = /\s*(?:"[^"]+"|'[^']+')\s*/;
+  var gettexRegex = new RegExp(gettextRegexPrefix + '\\(' + argRegex.source + '(?:,' + argRegex.source + ')?', 'gi');
 
   function extractGettext(str) {
     if (typeof(str) !== 'string') return '';

--- a/test/inputs/example.jade
+++ b/test/inputs/example.jade
@@ -28,3 +28,5 @@ p Have fun with #{ _('attributes') }
   )= _('This link is in line 28 and it better points somewhere!')
 
   span(data-custom=gettext("or you can"), data-extra=_('put multiple attributes'))= _('in line one line (30)')
+
+  a(href="http://some-link-here/" title=n_('Potato', 'Potatoes', 5))=n_('Apple', 'Apples', 1)

--- a/test/outputs/jade.pot
+++ b/test/outputs/jade.pot
@@ -62,3 +62,15 @@ msgstr ""
 #: inputs/example.jade:30
 msgid "in line one line (30)"
 msgstr ""
+
+#: inputs/example.jade:32
+msgid "Potato"
+msgid_plural "Potatoes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: inputs/example.jade:32
+msgid "Apple"
+msgid_plural "Apples"
+msgstr[0] ""
+msgstr[1] ""


### PR DESCRIPTION
Right now there's no support for plural forms in `jade`, because strings like `n_('Potato', 'Potatoes', 5)` is parsed into `_('Potato'` (leading letters and second argument are ignored by regex).
This is an attempt to fix it, including additions in test files.