### PR TITLE
Handle token type 'call' in jade parser so mixins work

### DIFF
--- a/lib/parsers/jade.js
+++ b/lib/parsers/jade.js
@@ -58,6 +58,9 @@ function parseJade(str, options) {
           .map(extractFromObj, token.attrs)
           .forEach(append, token);
         break;
+      case 'call':
+        append.call(token, extractGettext(token.args));
+        break;
       case 'text':
       case 'code':
         append.call(token, extractGettext(token.val));

--- a/test/inputs/example.jade
+++ b/test/inputs/example.jade
@@ -30,3 +30,5 @@ p Have fun with #{ _('attributes') }
   span(data-custom=gettext("or you can"), data-extra=_('put multiple attributes'))= _('in line one line (30)')
 
   a(href="http://some-link-here/" title=n_('Potato', 'Potatoes', 5))=n_('Apple', 'Apples', 1)
+
+  +mixin(_("Parameters in mixins"), _("They will be extracted as well"))

--- a/test/outputs/jade.pot
+++ b/test/outputs/jade.pot
@@ -74,3 +74,11 @@ msgid "Apple"
 msgid_plural "Apples"
 msgstr[0] ""
 msgstr[1] ""
+
+#: inputs/example.jade:34
+msgid "Parameters in mixins"
+msgstr ""
+
+#: inputs/example.jade:34
+msgid "They will be extracted as well"
+msgstr ""


### PR DESCRIPTION
See https://github.com/zaach/jsxgettext/issues/99