### PR TITLE
Only update creation date if content changes

### DIFF
--- a/lib/jsxgettext.js
+++ b/lib/jsxgettext.js
@@ -122,6 +122,7 @@ function parse(sources, options) {
       "project-id-version": options.projectIdVersion || "PACKAGE VERSION",
       "language-team": "LANGUAGE <LL@li.org>",
       "report-msgid-bugs-to": options.reportBugsTo,
+      "pot-creation-date": new Date().toISOString().replace('T', ' ').replace(/:\d{2}.\d{3}Z/, '+0000'),
       "po-revision-date": "YEAR-MO-DA HO:MI+ZONE",
       "language": "",
       "mime-version": "1.0",
@@ -139,11 +140,9 @@ function parse(sources, options) {
   var translations;
 
   try {
-    poJSON.headers["pot-creation-date"] = new Date().toISOString().replace('T', ' ').replace(/:\d{2}.\d{3}Z/, '+0000');
-
     // Always use the default context for now
     // TODO: Take into account different contexts
-    translations = poJSON.translations[''];
+    translations = JSON.parse(JSON.stringify(poJSON.translations['']));
   } catch (err) {
     if (useExisting)
       throw new Error("An error occurred while using the provided PO file. Please make sure it is valid by using `msgfmt -c`.");
@@ -248,6 +247,12 @@ function parse(sources, options) {
         comments.extracted = comments.extracted.split('\n').filter(dedupeNCoalesce).join('\n');
     });
   });
+
+  if (useExisting && JSON.stringify(translations) !== JSON.stringify(poJSON.translations[''])) {
+    // Only update the creation date if the content changed
+    poJSON.headers["pot-creation-date"] = new Date().toISOString().replace('T', ' ').replace(/:\d{2}.\d{3}Z/, '+0000');
+  }
+  poJSON.translations[''] = translations;
 
   return poJSON;
 }


### PR DESCRIPTION
Hey, we use jsxgettext together with the jsxgettext-loader in our project. This means that the translations will be updated whenever Webpack loads our files, which is very convenient. However, even if the content is not changed, the creation date will be updated and the file will be displayed as changed by Git. This is not so convenient.

This pull request fixes this. Although I think it would be better not to update the file at all if no translations changed, the structure of jsxgettext makes it really difficult to implement. So instead the date will only updated if the content changes, so effectively the file does not change if no translations change.
