### PR TITLE
fix keyword checking

### DIFF
--- a/lib/jsxgettext.js
+++ b/lib/jsxgettext.js
@@ -81,7 +81,8 @@ function getTranslatable(node, options) {
     }
   }
 
-  if (options.keyword.indexOf(funcName) === -1)
+  // if the found function name is not the keyword then skip this expression
+  if (options.keyword !== funcName)
     return false;
 
   // If the gettext function's name starts with "n" (i.e. ngettext or n_) and its first 2 arguments are strings, we regard it as a plural function


### PR DESCRIPTION
@BYK @zaach Could you check this? 

given `"translator.gettext".indexOf("get")` will skip the statement and add the keyword into parsed strings?