### PR TITLE
Handle JSX boolean attributes

### DIFF
--- a/lib/jsxgettext.js
+++ b/lib/jsxgettext.js
@@ -26,7 +26,7 @@ var walkBase = Object.assign({}, walk.base, {
   },
 
   JSXAttribute: function (node, st, c) {
-    if (node.value.type === 'JSXExpressionContainer') {
+    if (node.value && node.value.type === 'JSXExpressionContainer') {
       c(node.value, st);
     }
   },

--- a/test/inputs/react_component.jsx
+++ b/test/inputs/react_component.jsx
@@ -6,6 +6,10 @@ export default React.createClass({
         <div>
           {gettext('nested child component')}
         </div>
+        <input
+          type="text"
+          placeholder={gettext('component with boolean attribute')}
+          required />
       </div>
     );
   },

--- a/test/outputs/react_component.pot
+++ b/test/outputs/react_component.pot
@@ -13,3 +13,7 @@ msgstr ""
 #: inputs/react_component.jsx:7
 msgid "nested child component"
 msgstr ""
+
+#: inputs/react_component.jsx:11
+msgid "component with boolean attribute"
+msgstr ""


### PR DESCRIPTION
Fixes error

```
if (node.value.type === 'JSXExpressionContainer') {
              ^
TypeError: Cannot read property 'type' of null
```
