### PR TITLE
Add fuzzy flag to the header

### DIFF
--- a/lib/jsxgettext.js
+++ b/lib/jsxgettext.js
@@ -132,7 +132,7 @@ function parse(sources, options) {
     poJSON = {
       charset: "utf-8",
       headers: headers,
-      translations: {'': {} }
+      translations: {'': {'': {comments: {flag: 'fuzzy'}}} }
     };
   }
 


### PR DESCRIPTION
to avoid showing up the header strings mistakenly when the original string is empty.
