### PR TITLE
Handle parameters in handlebars

### DIFF
--- a/lib/parsers/handlebars.js
+++ b/lib/parsers/handlebars.js
@@ -16,7 +16,7 @@ function parseHandlebars(str, recurse) {
   var doubleQuotedStringWithEscapes = '"(([^"]*?(\\\\")?)+)"';
   var funcHelperRE = new RegExp("\\{\\{\\s*(\\w+)\\s+((\\w+)|(" +
                                 singleQuotedStringWithEscapes + ")|(" +
-                                doubleQuotedStringWithEscapes + "))\\s*\\}\\}");
+                                doubleQuotedStringWithEscapes + "))[^}]*}\\}");
 
   // an unescaped double quote starts with anything but an escape (\) or nothing
   var unescapedDoubleQuote = /([^\\])"|^"/g;

--- a/test/inputs/example.handlebars
+++ b/test/inputs/example.handlebars
@@ -12,3 +12,4 @@ And spurious { or }} or whatever markup doesn't confuse the parser.
 Escaped quotes are ok, {{gettext 'so let\'s test'}} them.
 Watch {{#helper}}out {{#foo}}{{#gettext}}for "quotes"{{/gettext}}{{/foo}}{{/helper}} too.
 So, do we {{gettext good}}?
+Ah! but {{gettext "I would like to do %1$s too" sprintf}}.

--- a/test/tests/handlebars.js
+++ b/test/tests/handlebars.js
@@ -15,12 +15,13 @@ exports['test handlebars'] = function (assert, cb) {
 
     assert.equal(typeof result, 'string', 'result is a string');
     assert.ok(result.length > 1, 'result is not empty');
-    assert.equal(result.split(/msgid ".+"/).length, 6, 'exactly five strings are found');
+    assert.equal(result.split(/msgid ".+"/).length, 7, 'exactly seven strings are found');
     assert.notEqual(result.indexOf('msgid "translated text"'), -1, 'result contains the first string');
     assert.notEqual(result.indexOf('msgid "block helper"'), -1, 'result contains the second string');
     assert.notEqual(result.indexOf('msgid "helpers"'), -1, 'result contains the third string');
     assert.notEqual(result.indexOf('msgid "so let\'s test"'), -1, 'result contains the fourth string');
     assert.notEqual(result.indexOf('msgid "for \\"quotes\\""'), -1, 'result contains the fourth string');
+    assert.notEqual(result.indexOf('msgid "I would like to do %1$s too"'), -1, 'result contains the sprintf string');
     cb();
   });
 };


### PR DESCRIPTION
## What does this do?

Adds support for parameters when using `gettext` in handlers in handlebars templates:

```
{{ gettext "My name is %s" person.name }}
```
## Ok - so what happens if you use that now?

Parsing hangs - indefinitely against my code - and it times out if you try this in the tests.
## Why do you want this?

To bring the parsing of handlerbars templates inline with that of other JS code. 

I've been running off my good friend Tim Peat's branch from a few years ago: https://github.com/timpeat/jsxgettext - this is basically a port of that. However, I'm now using ES6 in parts of the project so I'd like to start using the main package.

Thanks!!
