### PR TITLE
Add an option to customize acorn config.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -19,6 +19,7 @@ var opts = require("commander")
   .option('--project-id-version [version]', 'This is the project name and version of the generated package/catalog.')
   .option('--report-bugs-to [bug address]', 'An email address or URL where you can report bugs in the untranslated strings.')
   .option('-c, --add-comments [tag]', 'place comment blocks starting with TAG and preceding keyword lines in output file (default: "L10n:").')
+  .option('--parser-options [parser options]', 'A json to customize acorn parser.')
   .parse(process.argv);
 
 function gen(sources) {

--- a/lib/jsxgettext.js
+++ b/lib/jsxgettext.js
@@ -164,26 +164,26 @@ function parse(sources, options) {
     "^\\s*" + regExpEscape(tagName), // The "TAG" provided externally or "L10n:" by default
     "^\\/" // The "///" style comments which is the xgettext standard
   ].join("|"));
-  var parserOptions = Object.assign({}, {
-    ecmaVersion: 6,
-    sourceType: 'module',
-    plugins: { jsx: { allowNamespaces: false } },
-    onComment: function (block, text, start, end, line/*, column*/) {
-      text = text.match(commentRegex) && text.replace(/^\//, '').trim();
-
-      if (!text)
-        return;
-
-      astComments.push({
-        line : line,
-        value: text
-      });
-    },
-    locations: true
-  }, JSON.parse(options.parserOptions))
   Object.keys(sources).forEach(function (filename) {
     var source   = sources[filename].replace(/^#.*/, ''); // strip leading hash-bang
     var astComments = [];
+    var parserOptions = Object.assign({}, {
+      ecmaVersion: 6,
+      sourceType: 'module',
+      plugins: { jsx: { allowNamespaces: false } },
+      onComment: function (block, text, start, end, line/*, column*/) {
+        text = text.match(commentRegex) && text.replace(/^\//, '').trim();
+
+        if (!text)
+          return;
+
+        astComments.push({
+          line : line,
+          value: text
+        });
+      },
+      locations: true
+    }, options.parserOptions && JSON.parse(options.parserOptions));
     var ast      = parser.parse(source, parserOptions);
 
     // finds comments that end on the previous line

--- a/lib/jsxgettext.js
+++ b/lib/jsxgettext.js
@@ -164,26 +164,27 @@ function parse(sources, options) {
     "^\\s*" + regExpEscape(tagName), // The "TAG" provided externally or "L10n:" by default
     "^\\/" // The "///" style comments which is the xgettext standard
   ].join("|"));
+  var parserOptions = Object.assign({}, {
+    ecmaVersion: 6,
+    sourceType: 'module',
+    plugins: { jsx: { allowNamespaces: false } },
+    onComment: function (block, text, start, end, line/*, column*/) {
+      text = text.match(commentRegex) && text.replace(/^\//, '').trim();
+
+      if (!text)
+        return;
+
+      astComments.push({
+        line : line,
+        value: text
+      });
+    },
+    locations: true
+  }, JSON.parse(options.parserOptions))
   Object.keys(sources).forEach(function (filename) {
     var source   = sources[filename].replace(/^#.*/, ''); // strip leading hash-bang
     var astComments = [];
-    var ast      = parser.parse(source, {
-      ecmaVersion: 6,
-      sourceType: 'module',
-      plugins: { jsx: { allowNamespaces: false } },
-      onComment: function (block, text, start, end, line/*, column*/) {
-        text = text.match(commentRegex) && text.replace(/^\//, '').trim();
-
-        if (!text)
-          return;
-
-        astComments.push({
-          line : line,
-          value: text
-        });
-      },
-      locations: true
-    });
+    var ast      = parser.parse(source, parserOptions);
 
     // finds comments that end on the previous line
     function findComments(comments, line) {


### PR DESCRIPTION
Since we were not able to add `allowReserved` option for acorn itself, I just added a way to config it from very outside.
Now I'm using it like below:
```
node ./node_modules/jsxgettext/lib/cli.js -o OUTPUT_FILE --parser-options '{"allowReserved": true}' SOME_JS_FILE
```

Hope you'd like it.