### PR TITLE
add es8/es2017 support

### DIFF
--- a/lib/jsxgettext.js
+++ b/lib/jsxgettext.js
@@ -168,7 +168,7 @@ function parse(sources, options) {
     var source   = sources[filename].replace(/^#.*/, ''); // strip leading hash-bang
     var astComments = [];
     var parserOptions = Object.assign({}, {
-      ecmaVersion: 6,
+      ecmaVersion: 8,
       sourceType: 'module',
       plugins: { jsx: { allowNamespaces: false } },
       onComment: function (block, text, start, end, line/*, column*/) {

--- a/lib/jsxgettext.js
+++ b/lib/jsxgettext.js
@@ -39,11 +39,13 @@ var walkBase = Object.assign({}, walk.base, {
     c(node.expression, st);
   },
 
+  JSXText: function () {},
+
   JSXEmptyExpression: function () {}
 });
 
 function isStringLiteral(node) {
-  return node.type === 'Literal' && (typeof node.value === 'string');
+  return (node.type === 'Literal' || node.type === 'JSXText') && (typeof node.value === 'string');
 }
 
 function isStrConcatExpr(node) {

--- a/package.json
+++ b/package.json
@@ -43,21 +43,21 @@
   "bin": "lib/cli.js",
   "preferGlobal": true,
   "engineStrict": true,
-    "engines": {
-      "node": ">= 4.0.0"
+  "engines": {
+    "node": ">= 4.0.0"
   },
   "dependencies": {
-    "acorn": "^3.0.0",
-    "acorn-jsx": "^3.0.0",
-    "commander": "^2.9.0",
-    "escape-string-regexp": "^1.0.4",
-    "gettext-parser": "^1.1.2",
+    "acorn": "^5.1.2",
+    "acorn-jsx": "^4.0.1",
+    "commander": "^2.11.0",
+    "escape-string-regexp": "^1.0.5",
+    "gettext-parser": "^1.3.0",
     "jade": "^1.11.0"
   },
   "devDependencies": {
-    "jshint": "2.5.5",
+    "jshint": "2.9.5",
     "test": "0.6.0",
-    "i18n-abide": "0.0.17"
+    "i18n-abide": "0.0.25"
   },
   "scripts": {
     "test": "node ./node_modules/jshint/bin/jshint . && node test"


### PR DESCRIPTION
add es8/es2017 support. this is critical for trailing function commas (https://github.com/ternjs/acorn/issues/460), for example.